### PR TITLE
Add dynamic  URL for both success and failure redirects

### DIFF
--- a/controller/ControllerMain.ts
+++ b/controller/ControllerMain.ts
@@ -141,7 +141,7 @@ export const upload = new Elysia()
             fileDirectory: t.String(),
         })
     })
-    .post('/api/uploadImage', async ({ body, set, redirect }) => {
+    .post('/api/uploadImage', async ({ body, set, redirect, request }) => {
         const { name, file, passKey, fileDirectory } = body;
         console.log(body);
         interface FileReturn {
@@ -179,12 +179,21 @@ export const upload = new Elysia()
                 SecretKey: passKey,
             }
             const success: boolean = await ImageCip(cryptoPayload);
+            
+            // Get the protocol (http or https)
+            const protocol = request.headers.get('x-forwarded-proto') || 'http';
+            // Get the host from the request headers
+            const host = request.headers.get('host') || 'localhost:3000';
+            // Construct the base URL dynamically
+            const baseUrl = `${protocol}://${host}`;
+            
             if (!success) {
                 console.error("Failed to upload data.")
-                return redirect(`http://localhost:3000/uploadPage?folder=${fileDirectory}`)
+                return redirect(`${baseUrl}/uploadPage?folder=${fileDirectory}`);
             }
+            
             set.status = 200;
-            return redirect(`http://localhost:3000/uploadPage?folder=${fileDirectory}`)
+            return redirect(`${baseUrl}/uploadPage?folder=${fileDirectory}`);
         } catch (error) {
             set.status = 500;
             return {
@@ -244,4 +253,3 @@ export const upload = new Elysia()
           imageID: t.String()
         })
       });
-    


### PR DESCRIPTION
This pull request updates the `upload` API endpoint in `ControllerMain.ts` to improve flexibility and security by dynamically constructing the base URL for redirection. The most important changes include adding the `request` parameter to the handler function, dynamically determining the protocol and host, and replacing hardcoded URLs with the dynamically constructed base URL.

### Improvements to URL handling:

* Added the `request` parameter to the `/api/uploadImage` handler function to access request headers. (`[controller/ControllerMain.tsL144-R144](diffhunk://#diff-dca3f26d3a5be2bab5b87f23b59aeb5b2a4778674cb6822bce44d952a4dde903L144-R144)`)
* Dynamically determined the protocol (`http` or `https`) and host from request headers, and constructed the base URL for redirection. This replaces the previously hardcoded `http://localhost:3000` with a dynamically generated URL. (`[controller/ControllerMain.tsR182-R196](diffhunk://#diff-dca3f26d3a5be2bab5b87f23b59aeb5b2a4778674cb6822bce44d952a4dde903R182-R196)`)
* Updated all redirection logic to use the newly constructed `baseUrl` for consistent and flexible redirection paths. (`[controller/ControllerMain.tsR182-R196](diffhunk://#diff-dca3f26d3a5be2bab5b87f23b59aeb5b2a4778674cb6822bce44d952a4dde903R182-R196)`)