### PR TITLE
docs: Document .env in standard way

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+SECRET_KEY="Your secret here!"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -33,22 +33,12 @@ http://localhost:3000/
 
 ### ⚠ WORK IN PROGRESS 🔨
 
-## OPTIONAL ENV
-1. If you want to configure your hosting port, you can set it up in the .env prop file.
+## Configuring Environments
 
-Terminal:
-```
-mkdir .env
-```
+There is an example `.env.example` file in the root directory which you can copy and name it as `.env`. This file is used to store environment variables for the application.
 
-.env:
 ```
-PORT = 8000 
-```
-
-index.ts:
-```
-const key = process.env.SECRET_KEY
+cp .env.example .env
 ```
 
 ### MORE WORK IN PROGRESS 🎞


### PR DESCRIPTION
This PR improves the documentation and workflows for the environment file usage. It includes an example `.env` file that can be simply copied and named `.env` to get started.